### PR TITLE
Update wizmainwindow.h

### DIFF
--- a/src/wizmainwindow.h
+++ b/src/wizmainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QtGlobal>
 #include <QMainWindow>
+#include <unistd.h>
 
 #include "wizdef.h"
 #include "share/wizuihelper.h"


### PR DESCRIPTION
错误输出：
[ 72%] Building CXX object src/CMakeFiles/wiznote.dir/wizmainwindow.cpp.o  
/home/usr/software/WizQTClient/src/wizmainwindow.cpp: In member function ‘void Core::Internal::MainWindow::cleanOnQuit()’:
/home/usr/software/WizQTClient/src/wizmainwindow.cpp:198:20: error: ‘sleep’ was not declared in this scope
             sleep(1);
                    ^
make[2]: **\* [src/CMakeFiles/wiznote.dir/wizmainwindow.cpp.o] 错误 1
make[1]: **\* [src/CMakeFiles/wiznote.dir/all] 错误 2
make: **\* [all] 错误 2
