### PR TITLE
Update start-WizNote.sh

### DIFF
--- a/start-WizNote.sh
+++ b/start-WizNote.sh
@@ -1,1 +1,2 @@
-./bin/wiznote
+#./bin/wiznote
+./bin/WizNote


### PR DESCRIPTION
启动WizNote时，默认还是小写的wiznote，而不是修改之后的名称。
