### PR TITLE
fix missing head

### DIFF
--- a/src/sync/WizKMSync.h
+++ b/src/sync/WizKMSync.h
@@ -5,7 +5,7 @@
 #include <QMessageBox>
 #include <QWaitCondition>
 #include <QTimer>
-
+#include <QMutex>
 #include "WizSync.h"
 #include "WizKMServer.h"
 


### PR DESCRIPTION
error: incomplete definition of type "QMutex m_mutex"