### PR TITLE
add support of NSSupportsAutomaticGraphicsSwitching

### DIFF
--- a/build/osx/Info.plist
+++ b/build/osx/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-    <string>2.5.6</string>
+	<string>2.5.6</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>CFBundleName</key>
@@ -37,6 +37,8 @@
 	<key>ForAppStore</key>
 	<true/>
 	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 	<key>CFBundleLocalizations</key>
 	<array>


### PR DESCRIPTION
before:
WizNote requires high perf gpu,

![WizNote requires high perf gpu](https://user-images.githubusercontent.com/1926185/29739363-b288ccb8-8a2b-11e7-8ce4-d8db059779d2.png)

after:
WizNote doesn't requires high perf gpu,

![WizNote doesn't requires high perf gpu](https://user-images.githubusercontent.com/1926185/29739370-cfc5ccc2-8a2b-11e7-8b78-69e2aa7d97c1.png)

