### PR TITLE
Fix build error on debian9, with Qt5.7.1

### DIFF
--- a/linux-package.sh
+++ b/linux-package.sh
@@ -4,7 +4,7 @@ rm -rf ../WizQTClient-Release-Linux/*
 
 cd ../WizQTClient-Release-Linux
 
-cmake -DWIZNOTE_USE_QT5=NO -DCMAKE_BUILD_TYPE=Release ../WizQTClient && \
+cmake -Wno-dev -DWIZNOTE_USE_QT5=NO -DCMAKE_BUILD_TYPE=Release ../WizQTClient && \
 make -j5
 
 cd ..
@@ -14,7 +14,7 @@ cd WizNote
 mkdir bin
 cd bin
 
-cp ../../WizQTClient-Release-Linux/bin/WizNote ./
+cp ../../WizQTClient-Release-Linux/src/WizNote ./
 cp /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4 ./
 cp /usr/lib/x86_64-linux-gnu/libQtGui.so.4 ./
 cp /usr/lib/x86_64-linux-gnu//libQtXml.so.4 ./

--- a/src/sync/WizKMSync.h
+++ b/src/sync/WizKMSync.h
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include <QWaitCondition>
 #include <QTimer>
+#include <QMutex>
 
 #include "WizSync.h"
 #include "WizKMServer.h"


### PR DESCRIPTION
```
error msg:
[ 66%] Building CXX object src/CMakeFiles/WizNote.dir/sync/WizAvatarUploader.cpp.o
In file included from /home/dl/work/tmp/WizQTClient/src/sync/WizKMSync.cpp:1:0:
/src/sync/WizKMSync.h:100:12: error: field ‘m_mutex’ has incomplete type ‘QMutex’
     QMutex m_mutex;
            ^~~~~~~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/QWaitCondition:1:0,
                 from /home/dl/work/tmp/WizQTClient/src/sync/WizKMSync.h:6,
                 from /home/dl/work/tmp/WizQTClient/src/sync/WizKMSync.cpp:1:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qwaitcondition.h:53:7: note: forward declaration of ‘class QMutex’
 class QMutex;
       ^~~~~~
src/CMakeFiles/WizNote.dir/build.make:1233: recipe for target 'src/CMakeFiles/WizNote.dir/sync/WizKMSync.cpp.o' failed
make[2]: *** [src/CMakeFiles/WizNote.dir/sync/WizKMSync.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:254: recipe for target 'src/CMakeFiles/WizNote.dir/all' failed
make[1]: *** [src/CMakeFiles/WizNote.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```