### PR TITLE
optimize archlinux PKGBUILD: Use git + local file repo

### DIFF
--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Albert.Zhou <albert.zhou@wiz.cn>
 pkgname=wiznote
-pkgver=2.5.5
+pkgver=$(git symbolic-ref --short -q HEAD)
 pkgrel=1
 pkgdesc="Opensource cross-platform cloud based note-taking client"
 arch=('i686' 'x86_64')
@@ -9,16 +9,16 @@ license=('GPL3' 'custom')
 depends=('desktop-file-utils' 'hicolor-icon-theme' 'xdg-utils' 'qt5-base' 'qt5-webengine' 'qt5-websockets' 'openssl-1.0') # indirect: qt5-declarative qt5-sensors zlib glic gcc-libs
 makedepends=('cmake>=2.8.9' 'qt5-tools')
 install=wiznote.install
-#source=("$pkgname::git+https://github.com/WizTeam/WizQTClient.git#tag=$pkgver") # Use git is too slow
-#md5sums=('SKIP')
 _wiznote_project_name="WizQTClient"
-source=("$pkgname.tar.gz::https://github.com/WizTeam/WizQTClient/archive/$pkgver.zip")
-md5sums=('74350d8bc09bfbb5145ed761fc77e9c1')
+source=("$_wiznote_project_name-${pkgver}::git+file://$PWD/../../#tag=$pkgver") # Use git + local file repo
+md5sums=('SKIP')
+#source=("$pkgname.tar.gz::https://codeload.github.com/WizTeam/WizQTClient/tar.gz/$pkgver")
+#md5sums=('98061b6f8290d1464c980a3ecf666f91')
 
 build() {
 	cd "$srcdir/$_wiznote_project_name-${pkgver}"
-    cmake -DWIZNOTE_USE_QT5=YES -DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_BUILD_TYPE=Release .
-	make -j8
+	cmake -DWIZNOTE_USE_QT5=YES -DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_BUILD_TYPE=Release .
+	make -j$(nproc)
 }
 
 package() {


### PR DESCRIPTION
optimize archlinux PKGBUILD: Use git + local file repo

1. we do not need to download the source tar ball again since we already in the repo
2. use `git symbolic-ref --short -q HEAD` to get current branch name programmatically