### PR TITLE
Fix Qt 5.15 compatibility

### DIFF
--- a/src/sync/WizAvatarHost.cpp
+++ b/src/sync/WizAvatarHost.cpp
@@ -14,6 +14,7 @@
 #include <QPixmapCache>
 #include <QDateTime>
 #include <QPainter>
+#include <QPainterPath>
 
 #include "WizApiEntry.h"
 #include "../utils/WizPathResolve.h"


### PR DESCRIPTION
Fixes the following build error in latest Qt 5.15:

```
/build/wiznote/src/WizQTClient-2d4566aa1ff6e5a773d59e26df5ab07517931242/src/sync/WizAvatarHost.cpp: In static member function ‘static QPix
/build/wiznote/src/WizQTClient-2d4566aa1ff6e5a773d59e26df5ab07517931242/src/sync/WizAvatarHost.cpp:516:18: error: aggregate ‘QPainterPath
  516 |     QPainterPath path;
      |                  ^~~~
```