### PR TITLE
FIX: add level n heading shortcut

### DIFF
--- a/src/WizEditorToolBar.cpp
+++ b/src/WizEditorToolBar.cpp
@@ -19,7 +19,7 @@
 #include <QDebug>
 #include <QWidgetAction>
 #include <QActionGroup>
-
+#include <QShortcut>
 #include <QPixmap>
 
 #include "share/WizMisc.h"
@@ -1968,6 +1968,13 @@ WizEditorToolBar::WizEditorToolBar(WizExplorerApp& app, QWidget *parent)
     setToolbarType(TOOLBARTYPE_NORMAL);
     //setToolbarType(TOOLBARTYPE_HIGHLIGHTER);
     //setToolbarType(TOOLBARTYPE_OUTLINE);
+
+    new QShortcut(QKeySequence("Ctrl+1"), this, SLOT(on_comboParagraph_shortcutActivated()));
+    new QShortcut(QKeySequence("Ctrl+2"), this, SLOT(on_comboParagraph_shortcutActivated()));
+    new QShortcut(QKeySequence("Ctrl+3"), this, SLOT(on_comboParagraph_shortcutActivated()));
+    new QShortcut(QKeySequence("Ctrl+4"), this, SLOT(on_comboParagraph_shortcutActivated()));
+    new QShortcut(QKeySequence("Ctrl+5"), this, SLOT(on_comboParagraph_shortcutActivated()));
+    new QShortcut(QKeySequence("Ctrl+6"), this, SLOT(on_comboParagraph_shortcutActivated()));
 }
 
 void WizEditorToolBar::switchToNormalMode() {
@@ -3301,6 +3308,14 @@ void WizEditorToolBar::on_editor_justifyRight_triggered()
     m_editor->editorCommandExecuteJustifyRight();
 }
 
+void WizEditorToolBar::on_comboParagraph_shortcutActivated()
+{
+    QShortcut* shortcut = qobject_cast<QShortcut*>(sender());
+    QKeySequence seq = shortcut->key();
+    QString key_string = seq.toString();
+    int index = 56 - (int)key_string.back().toLatin1();
+    on_comboParagraph_indexChanged(index);
+}
 
 void WizEditorToolBar::on_comboParagraph_indexChanged(int index)
 {

--- a/src/WizEditorToolBar.h
+++ b/src/WizEditorToolBar.h
@@ -179,6 +179,7 @@ protected Q_SLOTS:
     void on_editor_justifyRight_triggered();
 
 
+    void on_comboParagraph_shortcutActivated();
     void on_comboParagraph_indexChanged(int index);
     void on_comboFontFamily_indexChanged(int index);
     void on_comboFontSize_indexChanged(const QString& strSize);


### PR DESCRIPTION
* add level 1(23456) heading shortcut ctrl + 1(23456)
* ubuntu 20.04 ctrl + 5 not working
* fix #614 