### PR TITLE
Fix Linux build: add missing normalbrowserobject.cpp/.h to CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set(wiznote_SOURCES
     share/WebSocketClientWrapper.cpp
     share/WebSocketTransport.cpp
     share/WizWebEngineView.cpp
+    share/normalbrowserobject.cpp
     widgets/WizTableSelector.cpp
     widgets/WizUserServiceExprDialog.cpp
 
@@ -330,6 +331,7 @@ set(wiznote_HEADERS
     share/WebSocketClientWrapper.h
     share/WebSocketTransport.h
     share/WizWebEngineView.h
+    share/normalbrowserobject.h
     WizWebEngineInjectObject.h
     widgets/WizShareLinkDialog.h
     share/WizAnalyzer.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,7 +349,7 @@ set(wiznote_HEADERS
     widgets/WizLocalProgressWebView.h
     widgets/WizCrashReportDialog.h
     widgets/WizCustomToolBar.h
-    widgets/WizTipsWidget.cpp
+    widgets/WizTipsWidget.h
     widgets/WizSingleDocumentView.h
     widgets/WizTemplatePurchaseDialog.h
     widgets/WizExecutingActionDialog.h


### PR DESCRIPTION
## Problem
Building on Linux fails at the link stage with:
```
undefined reference to `NormalBrowserObject::NormalBrowserObject(WizMainWindow*, QWebEngineView*, QObject*)'
```

## Root cause
`share/normalbrowserobject.cpp` and `share/normalbrowserobject.h` are present in the legacy `src/src.pro` qmake project file but were never added to `src/CMakeLists.txt` during the migration to CMake, so they're excluded from the build (and never moc'd, since the header declares `Q_OBJECT`).

## Fix
Added both files to the source/header lists in `src/CMakeLists.txt`.

## Build environment
- OS: Ubuntu 24.04.4 LTS (Noble Numbat)
- Kernel: 6.17.0-1028-oem
- Qt: 5.15.13 (system, /usr/lib/x86_64-linux-gnu)
- CMake: 3.28.3
- GCC: 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)

## Testing
Verified a clean `cmake` + `make -j$(nproc)` completes successfully and the resulting `WizNote` binary launches, connects, authenticates, and renders its main window.